### PR TITLE
ci: resolve plugin version from release tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish
 on:
   release:
-    types: [ released ]
+    types: [ released, prereleased ]
 jobs:
   publish:
     name: Release build and publish
@@ -14,8 +14,18 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 21
+      - name: Resolve version from release tag
+        id: version
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+].+)?$ ]]; then
+            echo "::error::Release tag '$tag' does not match expected vX.Y.Z format" >&2
+            exit 1
+          fi
+          echo "value=$version" >> "$GITHUB_OUTPUT"
       - name: Publish to MavenCentral
-        run: ./gradlew :plugin:publishPlugins
+        run: ./gradlew :plugin:publishPlugins -Pversion=${{ steps.version.outputs.value }}
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -13,7 +13,9 @@ kotlin {
 }
 
 group = "dev.yuyuyuyuyu"
-version = "0.6.1"
+version = (findProperty("version") as String?)
+    ?.takeIf { it.isNotBlank() && it != "unspecified" }
+    ?: "0.0.0-SNAPSHOT"
 
 gradlePlugin {
     website = "https://github.com/yu-ko-ba/ComposePWA#readme"


### PR DESCRIPTION
## Summary
- Derive the plugin version from the GitHub Release tag (stripping the leading `v`) and pass it to Gradle via `-Pversion`, so cutting a release no longer requires a separate commit to bump the hardcoded version in `plugin/build.gradle.kts`.
- Validate that the tag matches `vX.Y.Z` (optionally followed by a SemVer pre-release or build-metadata suffix); the workflow fails fast otherwise.
- When `-Pversion` is not supplied (i.e. local builds), fall back to `0.0.0-SNAPSHOT`.
- Trigger the publish workflow on `prereleased` in addition to `released`, so alpha/beta versions marked as pre-release on GitHub are published as well.

## Test plan
- [x] `./gradlew :plugin:properties -Pversion=1.2.3` reports `version: 1.2.3`
- [x] `./gradlew :plugin:properties` (no `-Pversion`) reports `version: 0.0.0-SNAPSHOT`
- End-to-end validation against a real GitHub Release cannot be done before merging: `release` events run the workflow from the default branch, and Gradle Plugin Portal publishes are irreversible. The first post-merge release will validate the workflow end-to-end; if tag parsing fails, the `Resolve version from release tag` step fails fast before any publish is attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)