### PR TITLE
fix(ci): trigger publish on `release: published`, run on Linux with JBR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,21 @@
 name: Publish
 on:
   release:
-    types: [released, prereleased]
+    types: [published]
 jobs:
   publish:
     name: Release build and publish
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          distribution: "zulu"
+          distribution: "jetbrains"
           java-version: 21
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Resolve version from release tag
         id: version
         run: |


### PR DESCRIPTION
## Why

`v0.7.0-alpha01` was published but the **Publish** workflow never ran.

The workflow listened for `release: [released, prereleased]`, but:
- `released` never fires for pre-releases (stable releases only).
- `prereleased` **does not fire for pre-releases published from a draft** — only `published` does (documented GitHub behavior).

The release object was created on 2026-06-19 and only published on 2026-06-21, i.e. published from a draft, so neither trigger type matched and nothing ran.

## Changes

- **Trigger:** `types: [released, prereleased]` → `types: [published]`. Covers stable releases, pre-releases, and releases published from drafts.
- **Runner:** `macOS-latest` → `ubuntu-latest`.
- **JDK:** distribution `zulu` → `jetbrains` (JetBrains Runtime), passing `GITHUB_TOKEN` to `setup-java` per [its docs](https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md) to avoid GitHub API rate limits when fetching JBR.

No `workflow_dispatch` added — publishing stays gated on release events only.

## Note

This does **not** retroactively publish `v0.7.0-alpha01` (its event already passed). To publish that build after merge, return the release to draft and re-publish it, or publish locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)