### PR TITLE
ci: rename the test jobs to say what they verify

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         run: ./gradlew :plugin:test
 
   plugin-output:
-    name: ComposePWA output (web assets the plugin emits)
+    name: Plugin output stays formatter-clean
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -79,7 +79,7 @@ jobs:
         run: npm run lint
 
   test-pwa:
-    name: Test ${{ matrix.target-name }} PWA
+    name: "E2E: build ${{ matrix.target-name }} PWA"
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Renames two `Tests` jobs so their names say what they actually verify:

- **`ComposePWA output (web assets the plugin emits)` → `Plugin output stays formatter-clean`** — the job runs the plugin against the example and checks that it neither rewrites committed, formatter-clean files (`git diff --exit-code`) nor emits files that fail the formatters (`npm run lint`).
- **`Test Wasm/JS PWA` → `E2E: build Wasm/JS PWA`** — the job builds the example as a PWA end-to-end and asserts the produced artifacts.

`Plugin unit tests` is unchanged (it really is the JUnit unit tests).

Only the job display names change; job ids and steps are untouched.

## ⚠️ Branch protection follow-up

GitHub matches required status checks by name. After this merges, update the required checks on `main` to the new names — otherwise PRs will wait forever for the old check names (`ComposePWA output (web assets the plugin emits)`, `Test Wasm PWA`, `Test JS PWA`) that no longer run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
