### PR TITLE
refactor: flatten the plugin into the composepwa package

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -35,7 +35,7 @@ gradlePlugin {
             description =
                 "This Gradle plugin provides a Gradle Task, that build your Compose Multiplatform Web App as a PWA."
             tags = listOf("compose multiplatform", "web", "pwa")
-            implementationClass = "dev.yuyuyuyuyu.ComposePwa"
+            implementationClass = "dev.yuyuyuyuyu.composepwa.ComposePwa"
         }
     }
 }

--- a/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/ComposePwa.kt
+++ b/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/ComposePwa.kt
@@ -1,7 +1,6 @@
-package dev.yuyuyuyuyu
+package dev.yuyuyuyuyu.composepwa
 
 import com.github.gradle.node.npm.task.NpxTask
-import dev.yuyuyuyuyu.tasks.InitComposePwa
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension

--- a/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/EnsureNecessaryHtmlTags.kt
+++ b/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/EnsureNecessaryHtmlTags.kt
@@ -1,4 +1,4 @@
-package dev.yuyuyuyuyu.tasks
+package dev.yuyuyuyuyu.composepwa
 
 import org.jsoup.Jsoup
 

--- a/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/InitComposePwa.kt
+++ b/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/InitComposePwa.kt
@@ -1,6 +1,5 @@
-package dev.yuyuyuyuyu.tasks
+package dev.yuyuyuyuyu.composepwa
 
-import dev.yuyuyuyuyu.tasks.shared.resolveTargetResourcesDirPath
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty

--- a/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/TargetResourcesDirPath.kt
+++ b/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/TargetResourcesDirPath.kt
@@ -1,4 +1,4 @@
-package dev.yuyuyuyuyu.tasks.shared
+package dev.yuyuyuyuyu.composepwa
 
 import org.gradle.api.GradleException
 import java.io.File

--- a/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/WebTarget.kt
+++ b/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/WebTarget.kt
@@ -1,4 +1,4 @@
-package dev.yuyuyuyuyu
+package dev.yuyuyuyuyu.composepwa
 
 /**
  * The two web targets the plugin supports, and everything that differs between them.

--- a/plugin/src/test/kotlin/dev/yuyuyuyuyu/composepwa/EnsureNecessaryHtmlTagsTest.kt
+++ b/plugin/src/test/kotlin/dev/yuyuyuyuyu/composepwa/EnsureNecessaryHtmlTagsTest.kt
@@ -6,9 +6,10 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
 
+/** The [ensureNecessaryHtmlTags] function's contract; the plugin-level spec lives in tests.yml. */
 class EnsureNecessaryHtmlTagsTest {
     @Test
-    fun returnsSameInstanceWhenBothTagsArePresent() {
+    fun `should return the same instance when both tags are already present`() {
         // Arrange
         val html =
             """
@@ -34,7 +35,36 @@ class EnsureNecessaryHtmlTagsTest {
     }
 
     @Test
-    fun insertsBothMissingTagsAndPreservesExistingFormatting() {
+    fun `should recognize tags reformatted by a formatter`() {
+        // Arrange
+        // Prettier splits long tags across lines; failing to recognize this shape is what
+        // once made the plugin and the formatter rewrite index.html back and forth forever.
+        val html =
+            """
+            <!doctype html>
+            <html lang="en">
+              <head>
+                <meta charset="UTF-8" />
+                <title>composeApp</title>
+                <script
+                  type="application/javascript"
+                  src="registerServiceWorker.js"
+                ></script>
+                <link rel="manifest" href="manifest.json" />
+              </head>
+              <body></body>
+            </html>
+            """.trimIndent()
+
+        // Act
+        val result = ensureNecessaryHtmlTags(html)
+
+        // Assert
+        assertSame(html, result)
+    }
+
+    @Test
+    fun `should insert both missing tags without reformatting the rest`() {
         // Arrange
         val html =
             """
@@ -73,7 +103,7 @@ class EnsureNecessaryHtmlTagsTest {
     }
 
     @Test
-    fun insertsOnlyTheMissingTag() {
+    fun `should insert only the missing tag`() {
         // Arrange
         val html =
             """
@@ -107,7 +137,7 @@ class EnsureNecessaryHtmlTagsTest {
     }
 
     @Test
-    fun isIdempotent() {
+    fun `should change nothing on a second run`() {
         // Arrange
         val html =
             """
@@ -132,7 +162,7 @@ class EnsureNecessaryHtmlTagsTest {
     }
 
     @Test
-    fun insertsTagsUsingTheFilesExistingLineEndings() {
+    fun `should insert tags using the file's existing line endings`() {
         // Arrange
         // A CRLF document, e.g. an index.html checked out on Windows.
         val crlf =

--- a/plugin/src/test/kotlin/dev/yuyuyuyuyu/composepwa/EnsureNecessaryHtmlTagsTest.kt
+++ b/plugin/src/test/kotlin/dev/yuyuyuyuyu/composepwa/EnsureNecessaryHtmlTagsTest.kt
@@ -1,4 +1,4 @@
-package dev.yuyuyuyuyu.tasks
+package dev.yuyuyuyuyu.composepwa
 
 import org.junit.Test
 import kotlin.test.assertContains

--- a/plugin/src/test/kotlin/dev/yuyuyuyuyu/composepwa/TargetResourcesDirPathTest.kt
+++ b/plugin/src/test/kotlin/dev/yuyuyuyuyu/composepwa/TargetResourcesDirPathTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 
+/** The index.html lookup's contract; the plugin-level spec lives in tests.yml. */
 class TargetResourcesDirPathTest {
     @get:Rule
     val projectDir = TemporaryFolder()

--- a/plugin/src/test/kotlin/dev/yuyuyuyuyu/composepwa/TargetResourcesDirPathTest.kt
+++ b/plugin/src/test/kotlin/dev/yuyuyuyuyu/composepwa/TargetResourcesDirPathTest.kt
@@ -1,6 +1,5 @@
-package dev.yuyuyuyuyu.tasks.shared
+package dev.yuyuyuyuyu.composepwa
 
-import dev.yuyuyuyuyu.WebTarget
 import org.gradle.api.GradleException
 import org.junit.Rule
 import org.junit.Test


### PR DESCRIPTION
## Summary

Post-#42 cleanup, no behavior change.

**Package.** The `tasks` / `tasks.shared` packages date from when the plugin defined six task classes; after the staging moved into `InitComposePwa` they held one task and two files of plain functions. Everything now lives flat in `dev.yuyuyuyuyu.composepwa`, matching the plugin id.

**Breaking (alpha):** the task class is now `dev.yuyuyuyuyu.composepwa.InitComposePwa`. This only affects builds that reference the class (e.g. `tasks.withType<InitComposePwa>`); applying the plugin by id is unaffected.

**Unit tests.** The `ensureNecessaryHtmlTags` tests get the same sentence-style names as the rest, each test class now carries a one-line note that it states a function's contract (the plugin-level spec lives in `tests.yml`), and one new check pins the old plugin-vs-formatter rewrite loop at the function level: tags a formatter has split across lines are still recognized, so nothing is ever re-inserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
