### PR TITLE
fix: serialize the workbox tasks to stop corrupting the npx cache

### DIFF
--- a/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/ComposePwa.kt
+++ b/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/ComposePwa.kt
@@ -20,11 +20,17 @@ class ComposePwa : Plugin<Project> {
             }
         }
 
-        // With index.html in webMain or commonMain, both init tasks stage the same
-        // directory; Gradle may run them in parallel under the configuration cache, so
-        // serialize them instead of coordinating concurrent writes (they are cheap).
+        // Gradle may run the two targets' tasks in parallel under the configuration
+        // cache, but they share state Gradle cannot see: both init tasks can stage the
+        // same resources directory (webMain/commonMain layouts), and both workbox tasks
+        // install workbox-cli into the same npx cache entry, corrupting it
+        // (TAR_ENTRY_ERROR). Everything here is cheap, so serialize the js pipeline
+        // after the wasm one instead of coordinating concurrent writes.
         project.tasks.named(WebTarget.Js.initTaskName).configure { task ->
             task.mustRunAfter(WebTarget.Wasm.initTaskName)
+        }
+        project.tasks.named(WebTarget.Js.buildAsPwaTaskName).configure { task ->
+            task.mustRunAfter(WebTarget.Wasm.buildAsPwaTaskName)
         }
 
         registerInitTasksAsResources(project)


### PR DESCRIPTION
## Summary

Every Dependabot PR was failing `should build each per-target page as a PWA` — the only job that builds both targets in a single Gradle invocation. Under the configuration cache, Gradle runs `buildWasmAsPwa` and `buildJsAsPwa` in parallel; both spawn `npx workbox-cli`, and when workbox-cli is not in the npx cache yet, the two npm processes install into the **same** cache entry (`~/.npm/_npx/<hash>` is keyed by the package spec) and corrupt it:

```
npm warn exec The following package was not found and will be installed: workbox-cli@7.4.1
npm warn tar TAR_ENTRY_ERROR ENOENT: no such file or directory, lstat '~/.npm/_npx/46fa2abac9cd1ac2/node_modules/...'
> Process 'command 'npx'' finished with non-zero exit value 1   (both tasks)
```

This is a flaky race, not something Dependabot-specific — it can just as well hit a real project that runs `wasmJsBrowserDistribution jsBrowserDistribution` in one command. It is the same shared-state-outside-Gradle problem as the init-task race fixed earlier, and gets the same fix: the js task is ordered after the wasm one (the workbox runs take seconds, so the lost parallelism is irrelevant).

Verified locally with a cold npx cache (`rm -rf ~/.npm/_npx`) and both distributions in one invocation: the tasks now run one after the other and both succeed. The existing `should build each per-target page as a PWA` job remains the guard.

After this merges, re-running the failed check on the Dependabot PRs should turn them green (their `pull_request` runs build the merge result against `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
