### PR TITLE
fix: deploy PWA assets by placement rules instead of assuming one directory

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,7 +137,7 @@ jobs:
         working-directory: test-projects/web-app
         run: ../../gradlew wasmJsBrowserDistribution jsBrowserDistribution
 
-      - name: Assert each page got its own web assets
+      - name: Assert each page got its own PWA assets
         run: |
           for buildDir in wasmJs js; do
             test -f "test-projects/web-app/build/dist/$buildDir/productionExecutable/serviceWorker.js" || { echo "::error::serviceWorker.js Not Found for $buildDir"; exit 1; }
@@ -153,6 +153,44 @@ jobs:
           for other in webMain commonMain; do
             test ! -e "test-projects/web-app/src/$other/resources" || { echo "::error::files were generated into $other"; exit 1; }
           done
+
+  test-spread-assets:
+    name: should work even if PWA assets are scattered across source sets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v7
+
+      - name: Setup build
+        uses: ./.github/actions/setup-build
+
+      - name: Spread index.html and the project's own PWA assets across source sets
+        run: |
+          mkdir -p test-projects/web-app/src/wasmJsMain/resources
+          mkdir -p test-projects/web-app/src/webMain/resources
+          mkdir -p test-projects/web-app/src/commonMain/resources/icons
+          cp test-projects/web-app/index.html test-projects/web-app/src/wasmJsMain/resources/index.html
+          echo '{ "name": "own manifest in webMain" }' > test-projects/web-app/src/webMain/resources/manifest.json
+          echo 'own icon in commonMain' > test-projects/web-app/src/commonMain/resources/icons/own-icon.png
+
+      - name: Build as PWA
+        working-directory: test-projects/web-app
+        run: ../../gradlew wasmJsBrowserDistribution
+
+      - name: Assert every asset was used from its own directory
+        run: |
+          src=test-projects/web-app/src
+          dist=test-projects/web-app/build/dist/wasmJs/productionExecutable
+          test -f "$src/wasmJsMain/resources/registerServiceWorker.js" || { echo '::error::registerServiceWorker.js was not created next to index.html'; exit 1; }
+          grep -q 'own manifest in webMain' "$src/webMain/resources/manifest.json" || { echo '::error::the project manifest.json was overwritten'; exit 1; }
+          test ! -e "$src/wasmJsMain/resources/manifest.json" || { echo '::error::a bundled manifest.json was created despite the webMain one'; exit 1; }
+          test ! -e "$src/wasmJsMain/resources/icons" || { echo '::error::bundled icons were created despite the commonMain ones'; exit 1; }
+          grep -q 'own manifest in webMain' "$dist/manifest.json" || { echo '::error::the merged page lost the webMain manifest.json'; exit 1; }
+          grep -q 'own icon in commonMain' "$dist/icons/own-icon.png" || { echo '::error::the merged page lost the commonMain icons'; exit 1; }
+          test -f "$dist/registerServiceWorker.js" || { echo '::error::registerServiceWorker.js Not Found in dist'; exit 1; }
+          test -f "$dist/serviceWorker.js" || { echo '::error::serviceWorker.js Not Found'; exit 1; }
 
   formatter:
     name: should not fight the formatter
@@ -192,7 +230,7 @@ jobs:
         run: npm run lint
 
   test-own-assets:
-    name: should keep the project's own web assets untouched
+    name: should not touch the project's own PWA assets
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -203,7 +241,7 @@ jobs:
       - name: Setup build
         uses: ./.github/actions/setup-build
 
-      - name: Seed index.html and the project's own web assets
+      - name: Seed index.html and the project's own PWA assets
         run: |
           resources=test-projects/web-app/src/webMain/resources
           mkdir -p "$resources/icons"
@@ -216,13 +254,56 @@ jobs:
         working-directory: test-projects/web-app
         run: ../../gradlew initComposePwaForWasm
 
-      - name: Assert every pre-existing web asset survived untouched
+      - name: Assert every pre-existing PWA asset survived untouched
         run: |
           resources=test-projects/web-app/src/webMain/resources
           grep -q 'own manifest' "$resources/manifest.json" || { echo '::error::manifest.json was overwritten'; exit 1; }
           grep -q 'own service worker registration' "$resources/registerServiceWorker.js" || { echo '::error::registerServiceWorker.js was overwritten'; exit 1; }
           test -f "$resources/icons/own-icon.png" || { echo "::error::the project's own icon was removed"; exit 1; }
           test ! -e "$resources/icons/icon-192x192.png" || { echo '::error::bundled icons were copied despite an existing manifest.json'; exit 1; }
+
+  test-cross-target-creation:
+    name: should not break a working build when creating missing PWA assets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v7
+
+      - name: Setup build
+        uses: ./.github/actions/setup-build
+
+      - name: Seed a shared index.html and wasm-only PWA assets
+        run: |
+          mkdir -p test-projects/web-app/src/webMain/resources
+          mkdir -p test-projects/web-app/src/wasmJsMain/resources/icons
+          cp test-projects/web-app/index.html test-projects/web-app/src/webMain/resources/index.html
+          echo '// wasm-specific service worker registration' > test-projects/web-app/src/wasmJsMain/resources/registerServiceWorker.js
+          echo '{ "name": "wasm-specific manifest" }' > test-projects/web-app/src/wasmJsMain/resources/manifest.json
+          echo 'wasm-specific icon' > test-projects/web-app/src/wasmJsMain/resources/icons/icon-192x192.png
+
+      - name: Build both targets as PWAs
+        working-directory: test-projects/web-app
+        run: ../../gradlew wasmJsBrowserDistribution jsBrowserDistribution
+
+      - name: Assert the js target got its own copies and the shared directory stayed clean
+        run: |
+          src=test-projects/web-app/src
+          test -f "$src/jsMain/resources/registerServiceWorker.js" || { echo '::error::registerServiceWorker.js was not mirrored into jsMain'; exit 1; }
+          test -f "$src/jsMain/resources/manifest.json" || { echo '::error::manifest.json was not mirrored into jsMain'; exit 1; }
+          test -f "$src/jsMain/resources/icons/icon-192x192.png" || { echo '::error::icons were not mirrored into jsMain'; exit 1; }
+          test ! -e "$src/webMain/resources/registerServiceWorker.js" || { echo '::error::registerServiceWorker.js leaked into the shared webMain'; exit 1; }
+          test ! -e "$src/webMain/resources/manifest.json" || { echo '::error::manifest.json leaked into the shared webMain'; exit 1; }
+          test ! -e "$src/webMain/resources/icons" || { echo '::error::icons leaked into the shared webMain'; exit 1; }
+          grep -q 'wasm-specific' "$src/wasmJsMain/resources/registerServiceWorker.js" || { echo '::error::the wasm-specific registerServiceWorker.js was overwritten'; exit 1; }
+          grep -q 'wasm-specific manifest' test-projects/web-app/build/dist/wasmJs/productionExecutable/manifest.json || { echo '::error::the wasm page lost its own manifest'; exit 1; }
+          if grep -q 'wasm-specific' test-projects/web-app/build/dist/js/productionExecutable/manifest.json; then
+            echo '::error::the js page was built with the wasm-specific manifest'; exit 1
+          fi
+          for buildDir in wasmJs js; do
+            test -f "test-projects/web-app/build/dist/$buildDir/productionExecutable/serviceWorker.js" || { echo "::error::serviceWorker.js Not Found for $buildDir"; exit 1; }
+          done
 
   test-missing-index-html:
     name: should fail helpfully when index.html is missing
@@ -265,6 +346,43 @@ jobs:
           done
           if grep -q 'src/wasmJsMain/resources/index.html' build-output-js.log; then
             echo '::error::a js build must not search the wasm target source set'; exit 1
+          fi
+
+  test-duplicated-assets:
+    name: should fail helpfully when the same PWA asset is in two source sets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v7
+
+      - name: Setup build
+        uses: ./.github/actions/setup-build
+
+      # The layout issue #47 reported: the project's own copy next to index.html, plus an
+      # untouched leftover from an old ComposePWA version in another source set.
+      - name: Seed the same PWA asset in two source sets
+        run: |
+          mkdir -p test-projects/web-app/src/commonMain/resources
+          mkdir -p test-projects/web-app/src/webMain/resources
+          cp test-projects/web-app/index.html test-projects/web-app/src/commonMain/resources/index.html
+          echo '// own service worker registration' > test-projects/web-app/src/commonMain/resources/registerServiceWorker.js
+          cp plugin/src/main/resources/registerServiceWorker.js test-projects/web-app/src/webMain/resources/registerServiceWorker.js
+
+      - name: Build expecting the conflict report
+        working-directory: test-projects/web-app
+        run: |
+          if ../../gradlew wasmJsBrowserDistribution > build-output.log 2>&1; then
+            echo '::error::the build unexpectedly succeeded with duplicated PWA assets'
+            exit 1
+          fi
+          grep -q 'ComposePWA found the same PWA asset in more than one resources directory' build-output.log || { echo '::error::the conflict report is missing'; tail -50 build-output.log; exit 1; }
+          grep -q 'registerServiceWorker.js is in:' build-output.log || { echo '::error::the conflicting file is not named'; exit 1; }
+          grep -qF -- '- src/webMain/resources/registerServiceWorker.js (identical to the bundled default; safe to delete)' build-output.log || { echo '::error::the untouched leftover is not marked safe to delete'; exit 1; }
+          grep -qE -- '- src/commonMain/resources/registerServiceWorker.js$' build-output.log || { echo '::error::the customized copy is missing or mislabeled'; exit 1; }
+          if grep -q 'is a duplicate but no duplicate handling strategy has been set' build-output.log; then
+            echo '::error::the build reached the cryptic Gradle duplicate error instead of failing early'; exit 1
           fi
 
   unit-tests:

--- a/README.md
+++ b/README.md
@@ -62,16 +62,27 @@ Your PWA will be generated in `composeApp/build/dist/wasmJs/productionExecutable
 
 ## What this plugin does
 
-The plugin first locates your web app's `index.html`. Each build searches only the
-resources directories that feed its target, and uses the one that contains the file:
+When you run the `wasmJsBrowserDistribution` or `jsBrowserDistribution` task, this
+plugin automatically does the following:
+
+- Creates `workbox-config-for-wasm.js` / `workbox-config-for-js.js` in the project
+  directory.
+- Creates `manifest.json`, `registerServiceWorker.js`, and `icons/*` next to your
+  `index.html`, skipping every file you already have.
+- Adds the necessary tags to your `index.html`.
+
+Each build searches only the resources directories that feed its target for
+`index.html` and the files above:
 
 - `wasmJsBrowserDistribution`: `src/webMain/resources`, `src/wasmJsMain/resources`,
   `src/commonMain/resources`
 - `jsBrowserDistribution`: `src/webMain/resources`, `src/jsMain/resources`,
   `src/commonMain/resources`
 
-Each file the plugin provides — `registerServiceWorker.js`, `manifest.json`, and the
-bundled `icons/` — then follows four rules, in order:
+### Where the files may live
+
+You don't have to keep everything in one place. Each file the plugin provides follows
+four rules, in order:
 
 1. If the same file is in two of the searched directories, the build fails with a report
    naming every copy: Gradle merges those directories into one page and cannot pick one.
@@ -85,24 +96,6 @@ bundled `icons/` — then follows four rules, in order:
 
 If you already have a `manifest.json`, the bundled `icons/` are not copied either — they
 only exist to back the bundled manifest.
-
-When you run the `wasmJsBrowserDistribution` task, this plugin automatically does the following:
-
-- Creates `workbox-config-for-wasm.js` in the project directory.
-- Creates these files, following the rules above:
-  - `manifest.json`
-  - `registerServiceWorker.js`
-  - `icons/*`
-- Adds the necessary tags to your `index.html`.
-
-When you run the `jsBrowserDistribution` task, this plugin automatically does the following:
-
-- Creates `workbox-config-for-js.js` in the project directory.
-- Creates these files, following the rules above:
-  - `manifest.json`
-  - `registerServiceWorker.js`
-  - `icons/*`
-- Adds the necessary tags to your `index.html`.
 
 ## Deploy to GitHub Pages
 

--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ four rules, in order:
    Copies identical to the bundled defaults are marked safe to delete.
 2. If the file already exists in one of the searched directories, it is used as is,
    wherever it lives, and is never overwritten.
-3. If it is missing, but the other web target keeps its own copy in
-   `src/wasmJsMain/resources` or `src/jsMain/resources`, the file is created in this
-   target's own resources directory, following that per-target convention.
+3. If it is missing, but the other web target keeps the file in its own resources
+   directory (`src/wasmJsMain/resources` or `src/jsMain/resources`), the file is
+   created in this target's own resources directory, following that per-target
+   convention.
 4. Otherwise, the file is created next to your `index.html`.
 
 If you already have a `manifest.json`, the bundled `icons/` are not copied either — they

--- a/README.md
+++ b/README.md
@@ -70,13 +70,26 @@ resources directories that feed its target, and uses the one that contains the f
 - `jsBrowserDistribution`: `src/webMain/resources`, `src/jsMain/resources`,
   `src/commonMain/resources`
 
-Files that already exist are left untouched. If you already have a `manifest.json`, the
-bundled `icons/` are not copied either — they only exist to back the bundled manifest.
+Each file the plugin provides — `registerServiceWorker.js`, `manifest.json`, and the
+bundled `icons/` — then follows four rules, in order:
+
+1. If the same file is in two of the searched directories, the build fails with a report
+   naming every copy: Gradle merges those directories into one page and cannot pick one.
+   Copies identical to the bundled defaults are marked safe to delete.
+2. If the file already exists in one of the searched directories, it is used as is,
+   wherever it lives, and is never overwritten.
+3. If it is missing, but the other web target keeps its own copy in
+   `src/wasmJsMain/resources` or `src/jsMain/resources`, the file is created in this
+   target's own resources directory, following that per-target convention.
+4. Otherwise, the file is created next to your `index.html`.
+
+If you already have a `manifest.json`, the bundled `icons/` are not copied either — they
+only exist to back the bundled manifest.
 
 When you run the `wasmJsBrowserDistribution` task, this plugin automatically does the following:
 
 - Creates `workbox-config-for-wasm.js` in the project directory.
-- Creates these files next to your `index.html`:
+- Creates these files, following the rules above:
   - `manifest.json`
   - `registerServiceWorker.js`
   - `icons/*`
@@ -85,7 +98,7 @@ When you run the `wasmJsBrowserDistribution` task, this plugin automatically doe
 When you run the `jsBrowserDistribution` task, this plugin automatically does the following:
 
 - Creates `workbox-config-for-js.js` in the project directory.
-- Creates these files next to your `index.html`:
+- Creates these files, following the rules above:
   - `manifest.json`
   - `registerServiceWorker.js`
   - `icons/*`
@@ -106,8 +119,8 @@ And you can check out a live example here:
 You can edit the following files to customize your PWA:
 
 - `workbox-config-for-wasm.js` / `workbox-config-for-js.js`
-- `manifest.json` (next to your `index.html`)
-- `icons/*` (next to your `index.html`)
+- `manifest.json` (next to your `index.html` by default)
+- `icons/*` (next to your `index.html` by default)
 
 ## Custom icon
 

--- a/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/ComposePwa.kt
+++ b/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/ComposePwa.kt
@@ -21,7 +21,7 @@ class ComposePwa : Plugin<Project> {
         }
 
         // Gradle may run the two targets' tasks in parallel under the configuration
-        // cache, but they share state Gradle cannot see: both init tasks can stage the
+        // cache, but they share state Gradle cannot see: both init tasks can write to the
         // same resources directory (webMain/commonMain layouts), and both workbox tasks
         // install workbox-cli into the same npx cache entry, corrupting it
         // (TAR_ENTRY_ERROR). Everything here is cheap, so serialize the js pipeline
@@ -43,9 +43,11 @@ class ComposePwa : Plugin<Project> {
         project.tasks.register(target.initTaskName, InitComposePwa::class.java) { task ->
             task.group = TASK_GROUP
             task.description =
-                "Copies the PWA web assets next to the ${target.name} target's index.html and tags it."
+                "Deploys the ${target.name} target's PWA assets and tags its index.html."
             task.projectDirectory.set(project.layout.projectDirectory)
             task.candidateResourcesDirPaths.set(target.candidateResourcesDirPaths)
+            task.ownResourcesDirPath.set(target.ownResourcesDirPath)
+            task.siblingResourcesDirPath.set(target.sibling.ownResourcesDirPath)
             task.workboxConfigFileName.set(target.workboxConfigFileName)
         }
     }
@@ -63,8 +65,8 @@ class ComposePwa : Plugin<Project> {
         }
     }
 
-    // Makes each web target's processResources depend on its init task, so the staged
-    // files take part in that target's resource merge.
+    // Makes each web target's processResources depend on its init task, so the files it
+    // deploys take part in that target's resource merge.
     private fun registerInitTasksAsResources(project: Project) {
         project.extensions.configure(KotlinMultiplatformExtension::class.java) { kmpExt ->
             WebTarget.entries.forEach { target ->

--- a/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/InitComposePwa.kt
+++ b/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/InitComposePwa.kt
@@ -18,44 +18,106 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 
 /**
- * Stages every file one web target's PWA needs: the workbox config in the project
- * directory, and registerServiceWorker.js, manifest.json, icons/, plus the required
- * tags next to that target's index.html.
+ * Deploys every file one web target's PWA needs: the workbox config in the project
+ * directory, and registerServiceWorker.js, manifest.json, and icons/ into the target's
+ * resources directories, following four rules:
+ *
+ * 1. A file already present in two searched directories fails the build with a report
+ *    naming every copy — Gradle merges those directories into one page and cannot pick one.
+ * 2. A file the project already has is used as is, wherever it lives.
+ * 3. A file the sibling target keeps in its own resources directory is mirrored into this
+ *    target's own resources directory — copying it into a directory both targets merge
+ *    would recreate the very duplicate rule 1 rejects.
+ * 4. A file the project has nowhere is created next to index.html, the one location the
+ *    project itself has chosen for its page.
  *
  * All steps run sequentially in this one action — instead of one task per file — so
- * ordering constraints (the icons decision must observe the manifest state from before
- * the bundled manifest is installed) are plain statement order, not inter-task rules.
+ * ordering constraints (the conflict scan must precede every copy; the icons decision
+ * must observe the manifest decision) are plain statement order, not inter-task rules.
  */
 @DisableCachingByDefault(because = "Not worth caching")
 abstract class InitComposePwa : DefaultTask() {
     @get:Internal
     abstract val projectDirectory: DirectoryProperty
 
-    /** Resources directories searched for index.html, in order. */
+    /** Resources directories searched for index.html and existing PWA assets, in order. */
     @get:Input
     abstract val candidateResourcesDirPaths: ListProperty<String>
+
+    /** This target's own source-set resources directory; where sibling-mirrored files go. */
+    @get:Input
+    abstract val ownResourcesDirPath: Property<String>
+
+    /** The sibling target's own resources directory; a copy there signals a per-target convention. */
+    @get:Input
+    abstract val siblingResourcesDirPath: Property<String>
 
     @get:Input
     abstract val workboxConfigFileName: Property<String>
 
     @TaskAction
-    fun stagePwaFiles() {
+    fun deployPwaFiles() {
         val projectDir = projectDirectory.get().asFile
-        val resourcesDir =
-            File(projectDir, resolveTargetResourcesDirPath(projectDir, candidateResourcesDirPaths.get()))
+        val candidateDirPaths = candidateResourcesDirPaths.get()
+        val indexHtmlDir = File(projectDir, resolveTargetResourcesDirPath(projectDir, candidateDirPaths))
 
         copyBundledFileIfMissing(workboxConfigFileName.get(), projectDir)
-        copyBundledFileIfMissing("registerServiceWorker.js", resourcesDir)
 
-        // The bundled icons exist solely to back the bundled manifest.json, which
-        // references them: when a manifest.json is already there (its contents are never
-        // inspected), the bundled manifest is not installed, so the icons are not either.
-        if (!resourcesDir.resolve("manifest.json").exists()) {
-            unzipBundledArchiveIfMissing("icons.zip", targetDirName = "icons", destDir = resourcesDir)
-            copyBundledFileIfMissing("manifest.json", resourcesDir)
+        val conflicts = findPwaAssetConflicts(projectDir, candidateDirPaths, bundledPwaAssets())
+        if (conflicts.isNotEmpty()) {
+            throw GradleException(pwaAssetConflictMessage(conflicts))
         }
 
-        ensureNecessaryHtmlTagsIn(resourcesDir.resolve("index.html"))
+        val candidateDirs = candidateDirPaths.map { File(projectDir, it) }
+
+        deployDir("registerServiceWorker.js", candidateDirs, indexHtmlDir)?.let { destDir ->
+            copyBundledFileIfMissing("registerServiceWorker.js", destDir)
+        }
+
+        // The bundled icons exist solely to back the bundled manifest.json, which
+        // references them: when the project keeps a manifest.json anywhere (its contents
+        // are never inspected), the bundled manifest is not copied, so the icons are not
+        // either.
+        deployDir("manifest.json", candidateDirs, indexHtmlDir)?.let { destDir ->
+            if (candidateDirs.none { it.resolve("icons").exists() }) {
+                unzipBundledArchiveIfMissing("icons.zip", targetDirName = "icons", destDir = destDir)
+            }
+            copyBundledFileIfMissing("manifest.json", destDir)
+        }
+
+        ensureNecessaryHtmlTagsIn(indexHtmlDir.resolve("index.html"))
+    }
+
+    /**
+     * Where to create the named bundled file, or null when the project already has it
+     * (rules 2-4; rule 1 has already rejected multiple copies).
+     */
+    private fun deployDir(
+        fileName: String,
+        candidateDirs: List<File>,
+        indexHtmlDir: File,
+    ): File? {
+        val projectDir = projectDirectory.get().asFile
+        return when {
+            candidateDirs.any { it.resolve(fileName).exists() } -> null
+            File(projectDir, siblingResourcesDirPath.get()).resolve(fileName).exists() ->
+                File(projectDir, ownResourcesDirPath.get())
+            else -> indexHtmlDir
+        }
+    }
+
+    /** Every file this task deploys into resources directories, keyed by its merged relative path. */
+    private fun bundledPwaAssets(): Map<String, ByteArray> {
+        val assets = linkedMapOf<String, ByteArray>()
+        listOf("registerServiceWorker.js", "manifest.json").forEach { fileName ->
+            assets[fileName] = bundledResource(fileName).openStream().use { it.readBytes() }
+        }
+        forEachBundledZipEntry("icons.zip") { entry, zis ->
+            if (!entry.isDirectory) {
+                assets[entry.name] = zis.readBytes()
+            }
+        }
+        return assets
     }
 
     private fun bundledResource(fileName: String): URL =
@@ -82,11 +144,20 @@ abstract class InitComposePwa : DefaultTask() {
     ) {
         // An existing directory is never overwritten.
         if (destDir.resolve(targetDirName).exists()) return
+        forEachBundledZipEntry(archiveFileName) { entry, zis ->
+            writeEntry(zis, entry, destDir)
+        }
+    }
+
+    private fun forEachBundledZipEntry(
+        archiveFileName: String,
+        action: (ZipEntry, ZipInputStream) -> Unit,
+    ) {
         bundledResource(archiveFileName).openStream().use { inputStream ->
             ZipInputStream(inputStream).use { zis ->
                 var entry = zis.nextEntry
                 while (entry != null) {
-                    writeEntry(zis, entry, destDir)
+                    action(entry, zis)
                     zis.closeEntry()
                     entry = zis.nextEntry
                 }

--- a/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/PwaAssetConflicts.kt
+++ b/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/PwaAssetConflicts.kt
@@ -1,0 +1,59 @@
+package dev.yuyuyuyuyu.composepwa
+
+import java.io.File
+
+/** One copy of a PWA asset: the resources directory holding it, and whether its bytes match the bundled default. */
+internal data class PwaAssetCopy(
+    val dirPath: String,
+    val isBundledDefault: Boolean,
+)
+
+/** A PWA asset present in more than one of the resources directories one target merges. */
+internal data class PwaAssetConflict(
+    val relativePath: String,
+    val copies: List<PwaAssetCopy>,
+)
+
+/**
+ * Finds every bundled asset path that exists in two or more of the searched directories.
+ * Such duplicates make Gradle's resource merge fail, so they must be reported before any
+ * file is copied. Each found copy is compared byte-for-byte with the bundled default, so
+ * the report can tell an untouched leftover from a file the user customized.
+ */
+internal fun findPwaAssetConflicts(
+    projectDir: File,
+    candidateDirPaths: List<String>,
+    bundledAssets: Map<String, ByteArray>,
+): List<PwaAssetConflict> =
+    bundledAssets.mapNotNull { (relativePath, bundledBytes) ->
+        val copies =
+            candidateDirPaths
+                .map { dirPath -> dirPath to File(projectDir, "$dirPath/$relativePath") }
+                .filter { (_, file) -> file.isFile }
+                .map { (dirPath, file) ->
+                    PwaAssetCopy(
+                        dirPath = dirPath,
+                        isBundledDefault = file.readBytes().contentEquals(bundledBytes),
+                    )
+                }
+        if (copies.size > 1) PwaAssetConflict(relativePath, copies) else null
+    }
+
+/** The error shown for [findPwaAssetConflicts] findings; it must name every copy and how to resolve it. */
+internal fun pwaAssetConflictMessage(conflicts: List<PwaAssetConflict>): String =
+    buildString {
+        append("ComposePWA found the same PWA asset in more than one resources directory. ")
+        append("Gradle merges those directories into one page and cannot pick one, ")
+        appendLine("so keep exactly one copy of each:")
+        conflicts.forEach { conflict ->
+            appendLine()
+            appendLine("  ${conflict.relativePath} is in:")
+            conflict.copies.forEach { copy ->
+                append("    - ${copy.dirPath}/${conflict.relativePath}")
+                if (copy.isBundledDefault) {
+                    append(" (identical to the bundled default; safe to delete)")
+                }
+                appendLine()
+            }
+        }
+    }

--- a/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/WebTarget.kt
+++ b/plugin/src/main/kotlin/dev/yuyuyuyuyu/composepwa/WebTarget.kt
@@ -20,6 +20,13 @@ internal enum class WebTarget(
     val initTaskName: String = "initComposePwaFor$name"
     val buildAsPwaTaskName: String = "build${name}AsPwa"
     val browserDistributionTaskName: String = "${targetName}BrowserDistribution"
+
+    /** This target's own source-set resources directory — the one the sibling target never sees. */
+    val ownResourcesDirPath: String = "src/$targetSourceSetName/resources"
+
     val candidateResourcesDirPaths: List<String> =
-        listOf("webMain", targetSourceSetName, "commonMain").map { "src/$it/resources" }
+        listOf("src/webMain/resources", ownResourcesDirPath, "src/commonMain/resources")
+
+    /** The other web target; its [ownResourcesDirPath] signals a per-target file convention. */
+    val sibling: WebTarget get() = if (this == Wasm) Js else Wasm
 }

--- a/plugin/src/test/kotlin/dev/yuyuyuyuyu/composepwa/PwaAssetConflictsTest.kt
+++ b/plugin/src/test/kotlin/dev/yuyuyuyuyu/composepwa/PwaAssetConflictsTest.kt
@@ -1,0 +1,132 @@
+package dev.yuyuyuyuyu.composepwa
+
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** The duplicate-asset report's contract; the plugin-level spec lives in tests.yml. */
+class PwaAssetConflictsTest {
+    @get:Rule
+    val projectDir = TemporaryFolder()
+
+    private val bundledBytes = "bundled default".toByteArray()
+
+    private fun createAsset(
+        sourceSetName: String,
+        relativePath: String,
+        content: ByteArray = bundledBytes,
+    ) {
+        val file = File(projectDir.root, "src/$sourceSetName/resources/$relativePath")
+        file.parentFile.mkdirs()
+        file.writeBytes(content)
+    }
+
+    private fun findConflicts(assetRelativePath: String = "registerServiceWorker.js") =
+        findPwaAssetConflicts(
+            projectDir.root,
+            WebTarget.Wasm.candidateResourcesDirPaths,
+            mapOf(assetRelativePath to bundledBytes),
+        )
+
+    @Test
+    fun `should report an asset present in two searched directories`() {
+        // Arrange
+        createAsset("webMain", "registerServiceWorker.js")
+        createAsset("commonMain", "registerServiceWorker.js")
+
+        // Act
+        val conflicts = findConflicts()
+
+        // Assert
+        assertEquals(1, conflicts.size)
+        assertEquals("registerServiceWorker.js", conflicts.single().relativePath)
+        assertEquals(
+            listOf("src/webMain/resources", "src/commonMain/resources"),
+            conflicts.single().copies.map { it.dirPath },
+        )
+    }
+
+    @Test
+    fun `should not report an asset present in exactly one directory`() {
+        // Arrange
+        createAsset("webMain", "registerServiceWorker.js")
+
+        // Act & Assert
+        assertTrue(findConflicts().isEmpty())
+    }
+
+    @Test
+    fun `should not look outside the searched directories`() {
+        // Arrange: jsMain is not part of a wasm build.
+        createAsset("webMain", "registerServiceWorker.js")
+        createAsset("jsMain", "registerServiceWorker.js")
+
+        // Act & Assert
+        assertTrue(findConflicts().isEmpty())
+    }
+
+    @Test
+    fun `should tell an untouched copy from a customized one`() {
+        // Arrange
+        createAsset("webMain", "manifest.json")
+        createAsset("commonMain", "manifest.json", content = "customized by the user".toByteArray())
+
+        // Act
+        val copies = findConflicts("manifest.json").single().copies
+
+        // Assert
+        assertTrue(copies.single { it.dirPath == "src/webMain/resources" }.isBundledDefault)
+        assertFalse(copies.single { it.dirPath == "src/commonMain/resources" }.isBundledDefault)
+    }
+
+    @Test
+    fun `should name every copy and mark untouched ones safe to delete`() {
+        // Arrange: the state left behind by ComposePWA versions up to 0.7.0-alpha01 (issue #47).
+        createAsset("webMain", "registerServiceWorker.js")
+        createAsset("commonMain", "registerServiceWorker.js", content = "the user's own".toByteArray())
+
+        // Act
+        val message = pwaAssetConflictMessage(findConflicts())
+
+        // Assert
+        assertContains(message, "found the same PWA asset in more than one resources directory")
+        assertContains(message, "registerServiceWorker.js is in:")
+        assertContains(
+            message,
+            "- src/webMain/resources/registerServiceWorker.js (identical to the bundled default; safe to delete)",
+        )
+        assertContains(message, "- src/commonMain/resources/registerServiceWorker.js\n")
+        assertFalse("commonMain/resources/registerServiceWorker.js (identical" in message)
+    }
+
+    @Test
+    fun `should list every conflicting asset in one report`() {
+        // Arrange
+        createAsset("webMain", "registerServiceWorker.js")
+        createAsset("commonMain", "registerServiceWorker.js")
+        createAsset("webMain", "icons/icon-192x192.png")
+        createAsset("wasmJsMain", "icons/icon-192x192.png")
+
+        // Act
+        val conflicts =
+            findPwaAssetConflicts(
+                projectDir.root,
+                WebTarget.Wasm.candidateResourcesDirPaths,
+                mapOf(
+                    "registerServiceWorker.js" to bundledBytes,
+                    "icons/icon-192x192.png" to bundledBytes,
+                ),
+            )
+        val message = pwaAssetConflictMessage(conflicts)
+
+        // Assert
+        assertEquals(2, conflicts.size)
+        assertContains(message, "registerServiceWorker.js is in:")
+        assertContains(message, "icons/icon-192x192.png is in:")
+    }
+}


### PR DESCRIPTION
Relates to #47 (linked on purpose without auto-close).

## What was wrong

`wasmJsProcessResources` failed with `Entry registerServiceWorker.js is a duplicate but no duplicate handling strategy has been set` whenever a PWA asset existed in more than one of the resources directories one target merges. Two verified ways to reach that state:

- a leftover from a plugin version that hardcoded `src/webMain/resources` (≤ 0.7.0-alpha01, the reporter's case), plus a fresh copy deployed next to index.html by 0.7.0-alpha02, or
- no old version at all: moving index.html (or a generated file) to another source set after a build, then rebuilding — the init task only checked next to index.html, so it deployed a second copy itself.

The error is working-tree-state dependent, not timing-flaky, which is why clean-checkout CI never caught it.

## What this changes

Each file the plugin provides (`registerServiceWorker.js`, `manifest.json`, `icons/`) now follows four rules, in order:

1. The same file in two searched directories fails the build with a report naming every copy — copies byte-identical to the bundled defaults are marked `safe to delete`. The report replaces the cryptic Gradle duplicate error (the init task fails before `processResources` runs).
2. A file the project already has is used as is, wherever it lives, and is never overwritten.
3. A file the sibling target keeps in its own resources directory is mirrored into this target's own directory — a shared directory never receives a copy that would duplicate the sibling's per-target one.
4. Only a file the project has nowhere is created next to index.html.

Sample of the new failure report:

```
> ComposePWA found the same PWA asset in more than one resources directory. Gradle merges
  those directories into one page and cannot pick one, so keep exactly one copy of each:

    registerServiceWorker.js is in:
      - src/webMain/resources/registerServiceWorker.js (identical to the bundled default; safe to delete)
      - src/commonMain/resources/registerServiceWorker.js
```

## Spec additions (tests.yml)

- `should work even if PWA assets are scattered across source sets`
- `should not break a working build when creating missing PWA assets`
- `should fail helpfully when the same PWA asset is in two source sets`

Jobs are grouped as normal behavior / must-not-do / failure behavior. `PwaAssetConflictsTest` covers the report's contract (every copy named; only untouched copies labeled safe to delete).

## Notes for review

- The conflict scan covers only the plugin-deployed asset paths; index.html and other project resources stay out of its jurisdiction.
- Existing user files always win over bundled ones, same as before (`should not touch the project's own PWA assets`, renamed from "should keep ... untouched").
- The task KDoc/vocabulary returns to "deploy" (an earlier refactor had silently replaced it with "stage").
- Custom `srcDirs` layouts are out of scope; the searched directories are the spec and appear in the error messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
