### PR TITLE
chore: make the example consume the published ComposePWA plugin

### DIFF
--- a/example/gradle/libs.versions.toml
+++ b/example/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 androidx-lifecycle = "2.11.0"
 composeMultiplatform = "1.11.1"
+composePwa = "0.7.0-alpha02"
 junit = "4.13.2"
 kotlin = "2.4.10"
 kotlin-wrappers = "2026.7.5"
@@ -23,4 +24,5 @@ wrappers-browser = { module = "org.jetbrains.kotlin-wrappers:kotlin-browser", ve
 [plugins]
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+composePwa = { id = "dev.yuyuyuyuyu.composepwa", version.ref = "composePwa" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/example/settings.gradle.kts
+++ b/example/settings.gradle.kts
@@ -2,11 +2,6 @@ rootProject.name = "ComposePWAExample"
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 pluginManagement {
-    // Use the ComposePWA plugin from this repository's source (the build under test)
-    // instead of a published version. This is the only change from a real consumer
-    // project, which would resolve the plugin from the Gradle Plugin Portal.
-    includeBuild("..")
-
     repositories {
         google {
             mavenContent {

--- a/example/webApp/build.gradle.kts
+++ b/example/webApp/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
 
-    // Builds this web app as a PWA. Resolved from source via includeBuild("../plugin")
-    // in settings.gradle.kts, so there is no version and no Gradle Plugin Portal lookup.
-    id("dev.yuyuyuyuyu.composepwa")
+    // Builds this web app as a PWA. Resolved from the Gradle Plugin Portal, exactly as a
+    // real consumer project would.
+    alias(libs.plugins.composePwa)
 }
 
 kotlin {


### PR DESCRIPTION
## What

Point the `example/` project at the ComposePWA plugin published on the **Gradle Plugin Portal** instead of building it from local source.

- **`example/settings.gradle.kts`** — drop `includeBuild("..")` (and its comment). `gradlePluginPortal()` was already in the `pluginManagement` repositories, so the plugin now resolves from there.
- **`example/gradle/libs.versions.toml`** — add the `composePwa` version (`0.7.0-alpha02`, the latest published) and a plugin alias, mirroring the README's version-catalog install instructions.
- **`example/webApp/build.gradle.kts`** — apply it via `alias(libs.plugins.composePwa)` instead of the version-less `id("dev.yuyuyuyuyu.composepwa")`.

## Why

The `includeBuild("..")` was the only thing separating `example/` from a genuine consumer project — the old comment said as much. Consuming the published plugin makes the example demonstrate exactly the setup a real user follows (and the GitHub Pages deploy now builds against the published version too).

## Notes for reviewers

- The CI build-under-test, `test-projects/web-app`, still uses `includeBuild("../..")` against local source and is **unaffected**.
- Verified locally: `./gradlew :webApp:help` in `example/` succeeds, confirming `0.7.0-alpha02` resolves from the Portal and `:webApp` configures with the plugin applied. A full `wasmJsBrowserDistribution` was not run.
- The pinned version is an alpha (`0.7.0-alpha02`, the latest published). Say the word if you'd rather pin the last stable (`0.6.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)