### PR TITLE
ci: group Dependabot minor and patch updates and merge them automatically

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @yuyuyuyuyu-dev

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,21 +5,41 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "gradle"
     directory: "/example"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge for minor and patch updates
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Read Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3.1.0
+
+      # Dependabot triggers this run, so `secrets` holds what is stored under
+      # Settings > Secrets and variables > Dependabot, not the Actions secrets.
+      - name: Create a token for the GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          client-id: ${{ secrets.AUTO_MERGE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.AUTO_MERGE_APP_PRIVATE_KEY }}
+
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Why

Every minor and patch bump arrived as its own pull request and had to be merged by hand, so even a quiet week produced a stream of them to review one at a time. Nothing about a green patch bump needs a human.

## What changed

- **`dependabot.yml` groups minor and patch version updates.** Each ecosystem gets a `minor-and-patch` group with no `patterns`, so every dependency it watches is in scope. Major updates stay outside the group and keep arriving one at a time.
- **A new `Dependabot auto-merge` workflow enables auto-merge on those pull requests.** It reads the pull request's Dependabot metadata and, when the highest bump in it is minor or patch, runs `gh pr merge --auto --squash`. GitHub then merges the pull request as soon as the required checks pass. `--squash` matches how this repository's history is built.
- **`CODEOWNERS` is gone.** Its single entry named the only maintainer as the owner of every path, so all it did was request a review on each pull request — including the ones that now merge on their own.

## Things worth a reviewer's attention

**A group cannot span package ecosystems.** "One pull request" therefore means one per entry in `dependabot.yml`: Gradle at the root, Gradle in `example/`, npm and GitHub Actions — up to four instead of one. `multi-ecosystem-groups` can span ecosystems, but the documented options for it require `patterns` and say nothing about `update-types`, so there is no documented way to keep such a group to minor and patch only. That is why it is not used here.

**`open-pull-requests-limit` stays at 1.** While a group pull request is open it occupies the only slot, so a major update waits until the group lands. Raising it to 2 would let one grouped and one major pull request coexist.

**The token comes from a GitHub App, not `GITHUB_TOKEN`,** so the merge is attributed to the app rather than to `github-actions[bot]`. A workflow run that Dependabot triggers reads Dependabot secrets rather than Actions secrets, which is why `AUTO_MERGE_APP_CLIENT_ID` and `AUTO_MERGE_APP_PRIVATE_KEY` live under Settings > Secrets and variables > Dependabot. `actions/create-github-app-token` v3 deprecates `app-id` in favour of `client-id`, so the secret holds the app's client ID.

**The `main` ruleset requires branches to be up to date.** Auto-merge does not update a stale branch itself; Dependabot rebases its own pull requests, so this resolves on its own, but a merge can wait for that rebase.

## Verification

- `prettier --check .`, `eslint .` and `actionlint` all pass locally on the whole repository.
- Repository settings were checked through the API after they were changed: `allow_auto_merge` is `true`, `allow_squash_merge` is `true`, and both Dependabot secrets exist. The app's private key is not in Actions secrets.
- Not verified from here: that the GitHub App is installed on this repository with Contents and Pull requests write access. Only an app-authenticated request can read that, so the first Dependabot pull request after this merges is the real test.

## After this merges

Grouping takes effect the next time Dependabot runs; it closes the individual pull requests it has open and reopens them as group ones. #87 and #83 are both patch updates, so they are the first candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
